### PR TITLE
Allow method:get to be omitted.

### DIFF
--- a/examples/MediaWikiActionApiEditTest.yaml
+++ b/examples/MediaWikiActionApiEditTest.yaml
@@ -5,13 +5,15 @@
 #
 # TODO: Add variable extraction option to be able to login, get CSRF token, and run tests w/ token
 
-suite: TestAction
-description: Testing page creation, edit, and delete in ActionAPI
+suite: MediaWiki action API CRUD
+description: Testing page creation, edit, and delete in MediaWiki's action API
 type: RPC
 
 tests:
   - description: Create, edit, and delete a page
     interaction:
+
+      # create and check content
       - request:
           method: post
           path: api.php
@@ -25,74 +27,73 @@ tests:
             text: A test page for phester
             token: +\
         response:
-          status: 200
           headers:
             content-type: !pcre/pattern: /application\/json/
-          body: !pcre/pattern: /"result":"Success"/
+          body:
+            edit:
+              result: Success
       - request:
-          method: get
           path: api.php
           parameters:
             action: parse
             page: phester
             format: json
         response:
-          status: 200
           headers:
             content-type: !pcre/pattern: /application\/json/
           body: !pcre/pattern: /A test page for phester/
+
+      # modify and check content
       - request:
           method: post
           path: api.php
-          parameters:
+          form-data:
             action: edit
             title: phester
             format: json
-          form-data:
             summary: phester edit
             text: Editing a test page for phester
             token: +\
         response:
-          status: 200
           headers:
             content-type: !pcre/pattern: /application\/json/
-          body: !pcre/pattern: /"result":"Success"/
+          body:
+            edit:
+              result: Success
       - request:
-          method: get
           path: api.php
           parameters:
             action: parse
             page: phester
             format: json
         response:
-          status: 200
           headers:
             content-type: !pcre/pattern: /application\/json/
           body: !pcre/pattern: /Editing a test page for phester/
+
+      # delete and check that it's gone
       - request:
           method: post
           path: api.php
-          parameters:
+          form-data:
             action: delete
             title: phester
             format: json
-          form-data:
             token: +\
         response:
-          status: 200
           headers:
             content-type: !pcre/pattern: /application\/json/
-          body: !pcre/pattern: /"delete":{"title":"Phester"/
+          body:
+            delete:
+              title: Phester
       - request:
-          method: get
           path: api.php
           parameters:
             action: parse
             page: phester
             format: json
         response:
-          status: 200
-          headers:
-            content-type: !pcre/pattern: /application\/json/
-          body: !pcre/pattern: /"code":"missingtitle"/
+          body:
+            error:
+              code: "missingtitle"
 

--- a/src/Instructions.php
+++ b/src/Instructions.php
@@ -62,7 +62,7 @@ class Instructions {
 
 		if ( !is_null( $value ) ) {
 			if ( $value  instanceof Instructions ) {
-				return is_array( $value->getArray() );
+				return is_array( $value->asArray() );
 			}
 			return is_array( $value );
 		}
@@ -74,25 +74,27 @@ class Instructions {
 	 * @return string containing the JSON representation of the array
 	 */
 	public function arrayToString() {
-		return json_encode( $this->getArray() );
+		return json_encode( $this->asArray() );
 	}
 
 	/**
 	 * Gets the array
 	 * @return array
 	 */
-	public function getArray() {
+	public function asArray() {
 		return $this->array;
 	}
 
 	/**
 	 * Gets the $key's value in lowercase
 	 * @param string|array $key
+     * @param string|null $default
 	 * @return string|null
 	 */
-	public function getLowerCase( $key ) {
-		if ( $this->has( $key ) && is_string( $this->get( $key ) ) ) {
-			return strtolower( $this->get( $key ) );
+	public function getLowerCase( $key, $default = null ) {
+	    $value = $this->get( $key, $default );
+		if ( is_string( $value ) ) {
+			return strtolower( $value );
 		}
 
 		return null;

--- a/src/TestSuite.php
+++ b/src/TestSuite.php
@@ -88,7 +88,7 @@ class TestSuite {
 	 */
 	private function runTests( $tests ) {
 		$output = [];
-		foreach ( $tests->getArray() as $test ) {
+		foreach ( $tests->asArray() as $test ) {
 			$test = new Instructions( $test );
 
 			if ( !$test->has( 'description' ) || !$test->has( 'interaction' ) ) {
@@ -117,11 +117,11 @@ class TestSuite {
 	 */
 	private function runInteraction( $interaction, $description ) {
 		$output = [];
-		foreach ( $interaction->getArray() as $rrPair ) {
+		foreach ( $interaction->asArray() as $rrPair ) {
 			$rrPair = new Instructions( $rrPair );
 			if ( $rrPair->has( 'request' ) ) {
 				$response = $rrPair->get( 'response' );
-				$expected = $response instanceof Instructions ? $response->getArray() : [];
+				$expected = $response instanceof Instructions ? $response->asArray() : [];
 				$expected['status'] = $expected['status'] ?? 200;
 
 				$errors = $this->executeRequest( $rrPair->get( 'request' ), $expected, $description );
@@ -152,10 +152,10 @@ class TestSuite {
 		$pathVar = $request->get( 'pathvar', '' );
 
 		if ( $pathVar instanceof Instructions ) {
-			$arr = $pathVar->getArray();
+			$arr = $pathVar->asArray();
 			$path = $this->urlEncode( $path, $arr );
 		}
-		$method = $request->getLowerCase( 'method' );
+		$method = $request->getLowerCase( 'method', 'get' );
 		$payload = [];
 
 		if ( $method === 'post' || $method === 'put' ) {
@@ -176,12 +176,12 @@ class TestSuite {
 		}
 
 		if ( $request->has( 'parameters' ) ) {
-			$payload['query'] = $request->get( 'parameters' )->getArray();
+			$payload['query'] = $request->get( 'parameters' )->asArray();
 		}
 
 		if ( $request->has( 'headers' ) &&
 			$request->get( [ 'headers', 'content-type' ] ) !== 'multipart/form-data' ) {
-			$payload['headers'] = $request->get( 'headers' )->getArray();
+			$payload['headers'] = $request->get( 'headers' )->asArray();
 		}
 
 		$payload['http_errors'] = false;
@@ -217,13 +217,13 @@ class TestSuite {
 		) {
 
 			$multipart = [];
-			foreach ( $request->get( $from )->getArray() as $key => $value ) {
+			foreach ( $request->get( $from )->asArray() as $key => $value ) {
 				$multipart[] = [ 'name' => $key, 'contents' => $value ];
 			}
 
 			$payload['multipart'] = $multipart;
 
-			$headers = $request->get( 'headers' )->getArray();
+			$headers = $request->get( 'headers' )->asArray();
 
 			// Guzzle multipart request option does not accept a content-type
 			// header and will throw an error if provided.
@@ -233,7 +233,7 @@ class TestSuite {
 				$payload['headers'] = $headers;
 			}
 		} else {
-			$payload['form_params'] = $request->get( $from )->getArray();
+			$payload['form_params'] = $request->get( $from )->asArray();
 		}
 
 		return $payload;
@@ -255,10 +255,10 @@ class TestSuite {
 				) {
 					$payload = $this->getFormDataPayload( $request, 'body' );
 				} else {
-					$payload['json'] = $request->get( 'body' )->getArray();
+					$payload['json'] = $request->get( 'body' )->asArray();
 				}
 			} else {
-				$payload['json'] = $request->get( 'body' )->getArray();
+				$payload['json'] = $request->get( 'body' )->asArray();
 			}
 		} elseif ( is_string( $request->get( 'body' ) ) ) {
 			$payload['body'] = $request->get( 'body' );

--- a/tests/InstructionsTest.php
+++ b/tests/InstructionsTest.php
@@ -116,7 +116,7 @@ class InstructionsTest extends TestCase {
 		$this->assertJsonStringEqualsJsonString( $this->instructions->arrayToString(), $string );
 	}
 
-	public function testGetArray() {
+	public function testAsArray() {
 		$array = [
 			'request' => [
 				'method' => 'GET',
@@ -130,7 +130,7 @@ class InstructionsTest extends TestCase {
 			]
 		];
 
-		$this->assertEquals( $this->instructions->getArray(), $array );
+		$this->assertEquals( $this->instructions->asArray(), $array );
 	}
 
 	public function testGetLowerCaseWithSetKey() {
@@ -140,5 +140,9 @@ class InstructionsTest extends TestCase {
 	public function testGetLowerCaseWithUnsetKey() {
 		$this->assertEquals( $this->instructions->getLowerCase( [ 'response', 'status' ] ), null );
 	}
+
+    public function testGetLowerCaseWithDefaultValue() {
+        $this->assertEquals( $this->instructions->getLowerCase( [ 'response', 'status' ], '123' ), '123' );
+    }
 
 }


### PR DESCRIPTION
Previously, omitting the method would lead to a bad HTTP with an empty
method being sent, resulting in a status 400.

This change also simplifies the MediaWikiActionApiEditTest example.
Besides omitting the method:get where possible, it now also makes
use of structured comparison of json responses instead of relying on
regular expressions.

For convenience, this change introduces a $default parameter
in Instructions::getLowerCase().

As an aside, this renames Instructions::getArray() to
Instructions::asArray() for consistency with other getts and with
hasArray().